### PR TITLE
Remove free text

### DIFF
--- a/plink2R/man/plink2R-package.Rd
+++ b/plink2R/man/plink2R-package.Rd
@@ -30,8 +30,6 @@ Maintainer: Who to complain to <yourfault@somewhere.net>
 \references{
 ~~ Literature or other references for background information ~~
 }
-~~ Optionally other standard keywords, one per line, from file KEYWORDS in ~~
-~~ the R documentation directory ~~
 \keyword{ package }
 \seealso{
 ~~ Optional links to other man pages, e.g. ~~


### PR DESCRIPTION
This PR fixes installation errors in R 3.6.1 

```
Error : (converted from warning) /tmp/Rtmpl7GWad/R.INSTALL19ff39d4fdb2/plink2R/man/plink2R-package.Rd:33: All text must be in a section
```

It simply removes a couple of freestanding lines of default text from the package description file.