### PR TITLE
Update plink2R-package.Rd

### DIFF
--- a/plink2R/man/plink2R-package.Rd
+++ b/plink2R/man/plink2R-package.Rd
@@ -30,8 +30,6 @@ Maintainer: Who to complain to <yourfault@somewhere.net>
 \references{
 ~~ Literature or other references for background information ~~
 }
-~~ Optionally other standard keywords, one per line, from file KEYWORDS in ~~
-~~ the R documentation directory ~~
 \keyword{ package }
 \seealso{
 ~~ Optional links to other man pages, e.g. ~~


### PR DESCRIPTION
Hi,
I tried to install the package from github and it failed with:

```
Error : (converted from warning) /scratch/RtmpJRR66L/R.INSTALL4fbd22957cec/plink2R/man/plink2R-package.Rd:33: All 
text must be in a section                                                                                         
Mon Jul 26 08:54:16 2021 add_route_ipv6(2001:610:188:149::/64 -> 2001:610:108:203d:e000::1 metric 101) dev tun0   │ERROR: installing Rd objects failed for package 'plink2R'      

```
Apperently there was something wrong with the man page template. Can you remove the faulty line or accept the pull request.

Thank you.

